### PR TITLE
hotfix: Fix CLA workflow 404 error blocking PR merges

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -5,21 +5,29 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        uses: contributor-assistant/github-action@v2.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/samiksha-xyz/Axiome/blob/main/docs/CLA.md'
-          branch: 'main'
-          allowlist: dependabot[bot],github-actions[bot]
+          branch: 'cla-signatures'
+          allowlist: suh4s,suhas,dependabot[bot],github-actions[bot]
           remote-organization-name: 'samiksha-xyz'
           remote-repository-name: 'Axiome'
           lock-pullrequest-aftermerge: false
+          empty-commit-flag: false
+          blockchain-storage-flag: false


### PR DESCRIPTION
## 🔧 Hotfix: CLA Workflow Configuration

### Problem
- CLA Assistant failing with 404 "Could not retrieve repository contents" error
- Blocking all PR merges to main branch
- Using incorrect branch configuration and missing required parameters

### Solution
- ✅ Change target branch from 'main' to 'cla-signatures' 
- ✅ Add missing users (suh4s, suhas) to allowlist
- ✅ Upgrade to contributor-assistant/github-action@v2.4.0
- ✅ Add required permissions block
- ✅ Add missing configuration flags (empty-commit-flag, blockchain-storage-flag)

### Impact
- Unblocks PR #1 (develop → main merge)
- Fixes CLA signature collection for future PRs
- Resolves 404 repository access error

### Testing
- CLA Assistant should now properly access cla-signatures branch
- Users in allowlist should pass automatically
- New contributors will be prompted to sign CLA

**Priority: Critical** - This is blocking the main development workflow.