### PR TITLE
hotfix: remove unsupported CLA Assistant parameters

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -12,7 +12,7 @@ permissions:
   statuses: write
 
 jobs:
-  CLAssistant:
+  CLAAssistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
@@ -29,5 +29,3 @@ jobs:
           remote-organization-name: 'samiksha-xyz'
           remote-repository-name: 'Axiome'
           lock-pullrequest-aftermerge: false
-          empty-commit-flag: false
-          blockchain-storage-flag: false


### PR DESCRIPTION
Remove empty-commit-flag and blockchain-storage-flag parameters that are not supported in v2.4.0 of the CLA Assistant action. This fixes the workflow validation errors and allows the CLA workflow to run properly.

This is a critical hotfix needed to unblock PR #1 since the CLA workflow runs from the main branch context.